### PR TITLE
Skip xnd tests if xnd is not installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ htmlcov/
 sandbox.py
 *.so
 build/
+.eggs/

--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -3,13 +3,11 @@ import uarray as ua
 import unumpy as np
 import numpy as onp
 import torch
-import xnd
 import dask.array as da
 import sparse
 import unumpy.numpy_backend as NumpyBackend
 
 import unumpy.torch_backend as TorchBackend
-import unumpy.xnd_backend as XndBackend
 import unumpy.dask_backend as DaskBackend
 import unumpy.sparse_backend as SparseBackend
 
@@ -17,7 +15,6 @@ ua.set_global_backend(NumpyBackend)
 
 LIST_BACKENDS = [
     (NumpyBackend, (onp.ndarray, onp.generic)),
-    (XndBackend, xnd.xnd),
     (DaskBackend, (da.Array, onp.generic)),
     (SparseBackend, (sparse.SparseArray, onp.ndarray, onp.generic)),
     pytest.param(
@@ -25,6 +22,28 @@ LIST_BACKENDS = [
         marks=pytest.mark.xfail(reason="PyTorch not fully NumPy compatible."),
     ),
 ]
+
+FULLY_TESTED_BACKENDS = [NumpyBackend, DaskBackend]
+
+try:
+    import unumpy.xnd_backend as XndBackend
+    import xnd
+
+    LIST_BACKENDS.append((XndBackend, xnd.xnd))
+    FULLY_TESTED_BACKENDS.append(XndBackend)
+except ImportError:
+
+    class XndBackend:
+        pass
+
+    class xnd:
+        pass
+
+    LIST_BACKENDS.append(
+        pytest.param(
+            (XndBackend, xnd), marks=pytest.mark.skip(reason="xnd is not importable")
+        )
+    )
 
 try:
     import unumpy.cupy_backend as CupyBackend
@@ -34,8 +53,6 @@ try:
 except ImportError:
     pass
 
-
-FULLY_TESTED_BACKENDS = (NumpyBackend, XndBackend, DaskBackend)
 
 EXCEPTIONS = {
     (DaskBackend, np.in1d),

--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -32,16 +32,9 @@ try:
     LIST_BACKENDS.append((XndBackend, xnd.xnd))
     FULLY_TESTED_BACKENDS.append(XndBackend)
 except ImportError:
-
-    class XndBackend:
-        pass
-
-    class xnd:
-        pass
-
     LIST_BACKENDS.append(
         pytest.param(
-            (XndBackend, xnd), marks=pytest.mark.skip(reason="xnd is not importable")
+            (None, None), marks=pytest.mark.skip(reason="xnd is not importable")
         )
     )
 
@@ -51,16 +44,9 @@ try:
 
     LIST_BACKENDS.append(pytest.param((CupyBackend, (cp.ndarray, cp.generic))))
 except ImportError:
-
-    class CupyBackend:
-        pass
-
-    class cupy:
-        pass
-
     LIST_BACKENDS.append(
         pytest.param(
-            (CupyBackend, cupy), marks=pytest.mark.skip(reason="cupy is not importable")
+            (None, None), marks=pytest.mark.skip(reason="cupy is not importable")
         )
     )
 

--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -51,7 +51,18 @@ try:
 
     LIST_BACKENDS.append(pytest.param((CupyBackend, (cp.ndarray, cp.generic))))
 except ImportError:
-    pass
+
+    class CupyBackend:
+        pass
+
+    class cupy:
+        pass
+
+    LIST_BACKENDS.append(
+        pytest.param(
+            (CupyBackend, cupy), marks=pytest.mark.skip(reason="cupy is not importable")
+        )
+    )
 
 
 EXCEPTIONS = {


### PR DESCRIPTION
I can't install XND because of xnd-project/xnd#46 so this is needed to run the test suite.