### PR TITLE
Compute meta with creating a dask array

### DIFF
--- a/unumpy/dask_backend.py
+++ b/unumpy/dask_backend.py
@@ -45,16 +45,16 @@ def wrap_uniform_create(func):
                 l -= s
 
         name = func.__name__ + "-" + hex(random.randrange(2 ** 64))
-
         dsk = {}
         with skip_backend(sys.modules[__name__]):
             for chunk_id in itertools.product(*map(lambda x: range(len(x)), chunks)):
                 shape = tuple(chunks[i][j] for i, j in enumerate(chunk_id))
                 dsk[(name,) + chunk_id] = func(shape, *args, **kwargs)
 
-            dtype = str(func((), *args, **kwargs).dtype)
+            meta = func(tuple(0 for _ in shape), *args, **kwargs)
+            dtype = str(meta.dtype)
 
-        return da.Array(dsk, name, chunks, dtype)
+        return da.Array(dsk, name, chunks, dtype=dtype, meta=meta)
 
     return wrapped
 


### PR DESCRIPTION
This PR updates `wrap_uniform_create` in the dask backend to compute the appropriate `meta` array-like object (e.g. a `sparse.COO` array) and pass it to `da.Array` when constructing a dask array. Currently, only `dtype` is passed to the `Array` constructor, so dask assumes `_meta` should be a `numpy.ndarray` by default.

For example, with the changes in this PR we have:

```python
In [1]: import uarray as ua
   ...: import unumpy as np
   ...: import unumpy.dask_backend as dask_backend
   ...: import unumpy.sparse_backend as sparse_backend

In [2]: with ua.set_backend(sparse_backend):
   ...:     with ua.set_backend(dask_backend):
   ...:         a = np.ones((100, 100))
   ...:

In [3]: a
Out[3]: dask.array<ones, shape=(100, 100), dtype=float64, chunksize=(100, 100), chunktype=sparse.COO>

In [4]: a._meta
Out[4]: <COO: shape=(0, 0), dtype=float64, nnz=0, fill_value=1.0>
```

while on the current `master`, we have:

```python
In [4]: a._meta
Out[4]: array([], shape=(0, 0), dtype=float64)
```