### PR TITLE
fix outdated imports in the CuPy backend

### DIFF
--- a/unumpy/cupy_backend.py
+++ b/unumpy/cupy_backend.py
@@ -2,8 +2,8 @@ try:
     import numpy as np
     import cupy as cp
     from uarray import Dispatchable, wrap_single_convertor
-    from .multimethods import ufunc, ufunc_list, ndarray
-    import unumpy.multimethods as multimethods
+    from unumpy import ufunc, ufunc_list, ndarray
+    import unumpy
     import functools
 
     from typing import Dict
@@ -12,7 +12,7 @@ try:
 
     __ua_domain__ = "numpy"
 
-    _implementations: Dict = {multimethods.ufunc.__call__: cp.ufunc.__call__}
+    _implementations: Dict = {unumpy.ufunc.__call__: cp.ufunc.__call__}
 
     def __ua_function__(method, args, kwargs):
         if method in _implementations:


### PR DESCRIPTION
In current master, the example below fails with
`AttributeError: module 'unumpy.cupy_backend' has no attribute '__ua_domain__'`

This ends up being due to some outdated imports that are updated in this PR.

```Python
import uarray as ua
import unumpy as np
import unumpy.cupy_backend as CupyBackend

with ua.set_backend(CupyBackend, coerce=True):
    ret = np.add([1], [2])
```