### PR TITLE
allow tests to run without xnd or ndtypes installed

### DIFF
--- a/.conda/environment_minimal.yml
+++ b/.conda/environment_minimal.yml
@@ -1,0 +1,22 @@
+name: uarray_min
+channels:
+  - pytorch
+  - defaults
+  - conda-forge
+dependencies:
+  - python=3.7
+  - pip
+  - sphinx
+  - sphinx_rtd_theme
+  - pytest
+  - pytest-cov
+  - mypy
+  - pytorch-cpu
+  - scipy
+  - dask
+  - sparse
+  - doc8
+  - black
+  - pip:
+    - pytest-mypy
+    - pytest-black

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,6 +25,32 @@ jobs:
       codeCoverageTool: Cobertura
       summaryFileLocation: "$(System.DefaultWorkingDirectory)/**/coverage.xml"
 
+- job: TestsMinimalEnv
+  pool:
+    vmImage: 'ubuntu-16.04'
+
+  steps:
+  - script: |
+      echo "##vso[task.prependpath]$CONDA/bin"
+      conda env create -f .conda/environment_minimal.yml
+    displayName: Prepare conda
+
+  - script: |
+      source activate uarray_min
+      pip install git+https://github.com/Quansight-Labs/uarray.git
+      pip install -e . --no-deps
+    displayName: Install package
+
+  - script: |
+      source activate uarray_min
+      pytest
+    displayName: Run tests
+
+  - task: PublishCodeCoverageResults@1
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: "$(System.DefaultWorkingDirectory)/**/coverage.xml"
+
 - job: Docs
   pool:
     vmImage: 'ubuntu-16.04'

--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -2,7 +2,6 @@ import pytest
 import uarray as ua
 import unumpy as np
 import numpy as onp
-from ndtypes import ndt
 import torch
 import dask.array as da
 import sparse
@@ -31,10 +30,12 @@ FULLY_TESTED_BACKENDS = [NumpyBackend, DaskBackend]
 try:
     import unumpy.xnd_backend as XndBackend
     import xnd
+    from ndtypes import ndt
 
     LIST_BACKENDS.append((XndBackend, xnd.xnd))
     FULLY_TESTED_BACKENDS.append(XndBackend)
 except ImportError:
+    XndBackend = None
     LIST_BACKENDS.append(
         pytest.param(
             (None, None), marks=pytest.mark.skip(reason="xnd is not importable")
@@ -210,7 +211,7 @@ def test_functions_coerce_with_dtype(backend, method, args, kwargs):
             pytest.xfail(reason="The backend has no implementation for this ufunc.")
 
     assert isinstance(ret, types)
-    if backend == XndBackend:
+    if XndBackend is not None and backend == XndBackend:
         assert ret.dtype == ndt(dtype)
     else:
         assert ret.dtype == dtype
@@ -266,7 +267,7 @@ def test_array_creation(backend, method, args, kwargs):
 
     if isinstance(ret, da.Array):
         ret.compute()
-    if backend == XndBackend:
+    if XndBackend is not None and backend == XndBackend:
         assert ret.dtype == ndt(dtype)
     else:
         assert ret.dtype == dtype

--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -35,7 +35,7 @@ try:
     LIST_BACKENDS.append((XndBackend, xnd.xnd))
     FULLY_TESTED_BACKENDS.append(XndBackend)
 except ImportError:
-    XndBackend = None
+    XndBackend = None  # type: ignore
     LIST_BACKENDS.append(
         pytest.param(
             (None, None), marks=pytest.mark.skip(reason="xnd is not importable")

--- a/unumpy/xnd_backend.py
+++ b/unumpy/xnd_backend.py
@@ -1,95 +1,93 @@
-import numpy as np
-from ndtypes import ndt
-import xnd
-import gumath.functions as fn
-import gumath as gu
-import uarray as ua
-from uarray import Dispatchable, wrap_single_convertor
-from unumpy import ufunc, ufunc_list, ndarray, dtype
-import unumpy
-import functools
+try:
+    import numpy as np
+    from ndtypes import ndt
+    import xnd
+    import gumath.functions as fn
+    import gumath as gu
+    import uarray as ua
+    from uarray import Dispatchable, wrap_single_convertor
+    from unumpy import ufunc, ufunc_list, ndarray, dtype
+    import unumpy
+    import functools
 
-from typing import Dict
+    from typing import Dict
 
-_ufunc_mapping: Dict[ufunc, np.ufunc] = {}
+    _ufunc_mapping: Dict[ufunc, np.ufunc] = {}
 
-__ua_domain__ = "numpy"
+    __ua_domain__ = "numpy"
 
+    _implementations: Dict = {
+        unumpy.ufunc.__call__: gu.gufunc.__call__,
+        unumpy.ufunc.reduce: gu.reduce,
+    }
 
-_implementations: Dict = {
-    unumpy.ufunc.__call__: gu.gufunc.__call__,
-    unumpy.ufunc.reduce: gu.reduce,
-}
+    def __ua_function__(method, args, kwargs):
+        if method in _implementations:
+            return _implementations[method](*args, **kwargs)
 
+        return _generic(method, args, kwargs)
 
-def __ua_function__(method, args, kwargs):
-    if method in _implementations:
-        return _implementations[method](*args, **kwargs)
+    @wrap_single_convertor
+    def __ua_convert__(value, dispatch_type, coerce):
+        if dispatch_type is ndarray:
+            return convert(value, coerce=coerce) if value is not None else None
 
-    return _generic(method, args, kwargs)
+        if dispatch_type is ufunc and hasattr(fn, value.name):
+            return getattr(fn, value.name)
 
+        if dispatch_type is dtype:
+            return ndt(str(value)) if value is not None else None
 
-@wrap_single_convertor
-def __ua_convert__(value, dispatch_type, coerce):
-    if dispatch_type is ndarray:
-        return convert(value, coerce=coerce) if value is not None else None
-
-    if dispatch_type is ufunc and hasattr(fn, value.name):
-        return getattr(fn, value.name)
-
-    if dispatch_type is dtype:
-        return ndt(str(value)) if value is not None else None
-
-    return NotImplemented
-
-
-def replace_self(func):
-    @functools.wraps(func)
-    def inner(self, *args, **kwargs):
-        if self not in _ufunc_mapping:
-            return NotImplemented
-
-        return func(_ufunc_mapping[self], *args, **kwargs)
-
-    return inner
-
-
-def _generic(method, args, kwargs):
-    try:
-        import numpy as np
-        import unumpy.numpy_backend as NumpyBackend
-    except ImportError:
         return NotImplemented
 
-    with ua.set_backend(NumpyBackend, coerce=True):
+    def replace_self(func):
+        @functools.wraps(func)
+        def inner(self, *args, **kwargs):
+            if self not in _ufunc_mapping:
+                return NotImplemented
+
+            return func(_ufunc_mapping[self], *args, **kwargs)
+
+        return inner
+
+    def _generic(method, args, kwargs):
         try:
-            out = method(*args, **kwargs)
-        except TypeError:
+            import numpy as np
+            import unumpy.numpy_backend as NumpyBackend
+        except ImportError:
             return NotImplemented
 
-    return convert_out(out, coerce=False)
+        with ua.set_backend(NumpyBackend, coerce=True):
+            try:
+                out = method(*args, **kwargs)
+            except TypeError:
+                return NotImplemented
+
+        return convert_out(out, coerce=False)
+
+    def convert_out(x, coerce):
+        if isinstance(x, (tuple, list)):
+            return type(x)(map(lambda x: convert_out(x, coerce=coerce), x))
+
+        return convert(x, coerce=coerce)
+
+    def convert(x, coerce):
+        if isinstance(x, xnd.array):
+            return x
+
+        try:
+            return xnd.array.from_buffer(memoryview(x))
+        except TypeError:
+            pass
+
+        if coerce:
+            return xnd.array(x)
+
+        if isinstance(x, (int, float, bool)):
+            return x
+
+        raise ua.BackendNotImplementedError("Unsupported output received.")
 
 
-def convert_out(x, coerce):
-    if isinstance(x, (tuple, list)):
-        return type(x)(map(lambda x: convert_out(x, coerce=coerce), x))
-
-    return convert(x, coerce=coerce)
-
-
-def convert(x, coerce):
-    if isinstance(x, xnd.array):
-        return x
-
-    try:
-        return xnd.array.from_buffer(memoryview(x))
-    except TypeError:
-        pass
-
-    if coerce:
-        return xnd.array(x)
-
-    if isinstance(x, (int, float, bool)):
-        return x
-
-    raise ua.BackendNotImplementedError("Unsupported output received.")
+except ImportError:
+    pass


### PR DESCRIPTION
These small changes allow the test suite to be run without `xnd` or `ndtypes` installed. (It looks like that was already the intention for `xnd`, but then there were statements like `backend == XndBackend` in some test cases that would fail if it was not present.)