### PR TITLE
handle args in _first2argreplacer

### DIFF
--- a/unumpy/_multimethods.py
+++ b/unumpy/_multimethods.py
@@ -56,11 +56,11 @@ def _reduce_argreplacer(args, kwargs, arrays):
 
 
 def _first2argreplacer(args, kwargs, arrays):
-    def func(a, b, **kw):
+    def func(a, b, *args, **kw):
         kw_out = kw.copy()
         if "out" in kw:
             kw_out["out"] = arrays[2]
-        return arrays[:2], kw_out
+        return arrays[:2] + args, kw_out
 
     return func(*args, **kwargs)
 

--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -163,6 +163,8 @@ def replace_args_kwargs(method, backend, args, kwargs):
         (np.pad, ([1, 2, 3, 4, 5], (2, 3), "constant"), dict(constant_values=(4, 6))),
         (np.searchsorted, ([1, 2, 3, 4, 5], 2), {}),
         (np.compress, ([True, False, True, False], [0, 1, 2, 3]), {}),
+        # the following case tests the fix in Quansight-Labs/unumpy#36
+        (np.compress, ([False, True], [[1, 2], [3, 4], [5, 6]], 1), {}),
         (np.extract, ([True, False, True, False], [0, 1, 2, 3]), {}),
         (np.count_nonzero, ([True, False, True, False],), {}),
     ],


### PR DESCRIPTION
This PR adds handling of `*args` to `_first2argreplacer`

In current master:

```Python
import uarray as ua
import unumpy as np
import unumpy.numpy_backend as NumpyBackend

with ua.set_backend(NumpyBackend, coerce=True):
    ret = np.compress([False, True], np.array([[1, 2], [3, 4], [5, 6]]), 1)
```
fails with:
`TypeError: func() takes 2 positional arguments but 3 were given`

but it should be possible to pass the third argument (`axis`) positionally.

This PR fixes cases like the one above.


