### PR TITLE
add several new multimethods

### DIFF
--- a/unumpy/_multimethods.py
+++ b/unumpy/_multimethods.py
@@ -937,7 +937,35 @@ def vstack(tup):
     return tup
 
 
-@create_numpy(_first_argreplacer)
+def _diff_default(a, n=1, axis=-1):
+    if n == 0:
+        return a
+    if n < 0:
+        raise ValueError("order must be non-negative but got " + repr(n))
+
+    a = asarray(a)
+    nd = a.ndim
+    if nd == 0:
+        raise ValueError("diff requires input that is at least one dimensional")
+    if axis < -nd or axis >= nd:
+        raise ValueError("axis out of range")
+    axis = axis % nd
+
+    slice1 = [slice(None)] * nd
+    slice2 = [slice(None)] * nd
+    slice1[axis] = slice(1, None)
+    slice2[axis] = slice(None, -1)
+    slice1 = tuple(slice1)
+    slice2 = tuple(slice2)
+
+    op = not_equal if a.dtype.kind == "b" else subtract
+    for _ in range(n):
+        a = op(a[slice1], a[slice2])
+
+    return a
+
+
+@create_numpy(_first_argreplacer, default=_diff_default)
 @all_of_type(ndarray)
 def diff(a, n=1, axis=-1):
     return a

--- a/unumpy/_multimethods.py
+++ b/unumpy/_multimethods.py
@@ -460,7 +460,13 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
     return (a, mark_non_coercible(out))
 
 
-@create_numpy(_reduce_argreplacer)
+def _ptp_default(a, axis=None, out=None, keepdims=False):
+    result = max(a, axis=axis, out=out, keepdims=keepdims)
+    result -= min(a, axis=axis, out=None, keepdims=keepdims)
+    return result
+
+
+@create_numpy(_reduce_argreplacer, default=_ptp_default)
 @all_of_type(ndarray)
 def ptp(a, axis=None, out=None, keepdims=False):
     return (a, mark_non_coercible(out))

--- a/unumpy/_multimethods.py
+++ b/unumpy/_multimethods.py
@@ -687,16 +687,34 @@ def compress(condition, a, axis=None, out=None):
     return (condition, a, out)
 
 
-@create_numpy(_first2argreplacer)
+def _linspace_argreplacer(args, kwargs, arrays):
+    def func(a, b, num=50, endpoint=True, retstep=False, dtype=None, axis=0):
+        kw_out = dict(num=num, endpoint=endpoint, retstep=retstep, axis=axis)
+        kw_out["dtype"] = arrays[2]
+        return arrays[:2], kw_out
+
+    return func(*args, **kwargs)
+
+
+@create_numpy(_linspace_argreplacer)
 @all_of_type(ndarray)
 def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None, axis=0):
-    return (start, stop)
+    return (start, stop, mark_dtype(dtype))
 
 
-@create_numpy(_first2argreplacer)
+def _logspace_argreplacer(args, kwargs, arrays):
+    def func(a, b, num=50, endpoint=True, base=10, dtype=None, axis=0):
+        kw_out = dict(num=num, endpoint=endpoint, base=base, axis=axis)
+        kw_out["dtype"] = arrays[2]
+        return arrays[:2], kw_out
+
+    return func(*args, **kwargs)
+
+
+@create_numpy(_logspace_argreplacer)
 @all_of_type(ndarray)
 def logspace(start, stop, num=50, endpoint=True, base=10, dtype=None, axis=0):
-    return (start, stop)
+    return (start, stop, mark_dtype(dtype))
 
 
 @create_numpy(

--- a/unumpy/_multimethods.py
+++ b/unumpy/_multimethods.py
@@ -905,6 +905,12 @@ def diff(a, n=1, axis=-1):
     return a
 
 
+@create_numpy(_args_argreplacer)
+@all_of_type(ndarray)
+def gradient(a, *varargs, edge_order=1, axis=None):
+    return (a,) + varargs
+
+
 class _Recurser(object):
     def __init__(self, recurse_if):
         self.recurse_if = recurse_if

--- a/unumpy/_multimethods.py
+++ b/unumpy/_multimethods.py
@@ -687,6 +687,18 @@ def compress(condition, a, axis=None, out=None):
     return (condition, a, out)
 
 
+@create_numpy(_first2argreplacer)
+@all_of_type(ndarray)
+def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None, axis=0):
+    return (start, stop)
+
+
+@create_numpy(_first2argreplacer)
+@all_of_type(ndarray)
+def logspace(start, stop, num=50, endpoint=True, base=10, dtype=None, axis=0):
+    return (start, stop)
+
+
 @create_numpy(
     _first2argreplacer,
     default=lambda condition, arr: compress(ravel(condition), ravel(arr)),

--- a/unumpy/_multimethods.py
+++ b/unumpy/_multimethods.py
@@ -562,6 +562,12 @@ def broadcast_to(array, shape, subok=False):
     return (array,)
 
 
+@create_numpy(_args_argreplacer)
+@all_of_type(ndarray)
+def meshgrid(*args, indexing="xy", sparse=False, copy=True):
+    return args
+
+
 def _first_argreplacer(args, kwargs, arrays1):
     def func(arrays, *args, **kwargs):
         return (arrays1,) + args, kwargs

--- a/unumpy/_multimethods.py
+++ b/unumpy/_multimethods.py
@@ -899,6 +899,12 @@ def vstack(tup):
     return tup
 
 
+@create_numpy(_first_argreplacer)
+@all_of_type(ndarray)
+def diff(a, n=1, axis=-1):
+    return a
+
+
 class _Recurser(object):
     def __init__(self, recurse_if):
         self.recurse_if = recurse_if

--- a/unumpy/_multimethods.py
+++ b/unumpy/_multimethods.py
@@ -460,6 +460,12 @@ def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
     return (a, mark_non_coercible(out))
 
 
+@create_numpy(_reduce_argreplacer)
+@all_of_type(ndarray)
+def ptp(a, axis=None, out=None, keepdims=False):
+    return (a, mark_non_coercible(out))
+
+
 # set routines
 @create_numpy(_self_argreplacer)
 @all_of_type(ndarray)

--- a/unumpy/_multimethods.py
+++ b/unumpy/_multimethods.py
@@ -717,7 +717,13 @@ def _logspace_argreplacer(args, kwargs, arrays):
     return func(*args, **kwargs)
 
 
-@create_numpy(_logspace_argreplacer)
+def _logspace_default(start, stop, num=50, endpoint=True, base=10, dtype=None, axis=0):
+    return base ** linspace(
+        start, stop, num=num, endpoint=endpoint, dtype=dtype, axis=axis
+    )
+
+
+@create_numpy(_logspace_argreplacer, default=_logspace_default)
 @all_of_type(ndarray)
 def logspace(start, stop, num=50, endpoint=True, base=10, dtype=None, axis=0):
     return (start, stop, mark_dtype(dtype))

--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -68,6 +68,7 @@ EXCEPTIONS = {
     (DaskBackend, np.sort_complex),
     (DaskBackend, np.msort),
     (DaskBackend, np.searchsorted),
+    (DaskBackend, np.logspace),
 }
 
 
@@ -166,6 +167,8 @@ def replace_args_kwargs(method, backend, args, kwargs):
         (np.compress, ([True, False, True, False], [0, 1, 2, 3]), {}),
         (np.extract, ([True, False, True, False], [0, 1, 2, 3]), {}),
         (np.count_nonzero, ([True, False, True, False],), {}),
+        (np.linspace, (0, 100, 200), {}),
+        (np.logspace, (0, [100, 20], 200), {}),
     ],
 )
 def test_functions_coerce(backend, method, args, kwargs):

--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -221,6 +221,7 @@ def test_functions_coerce_with_dtype(backend, method, args, kwargs):
     "method, args, kwargs",
     [
         (np.broadcast_arrays, ([1, 2], [[3, 4]]), {}),
+        (np.meshgrid, ([1, 2, 3], [4, 5], [0, 1]), {}),
         (np.nonzero, ([3, 1, 2, 4],), {}),
         (np.where, ([[3, 1, 2, 4]],), {}),
     ],

--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -131,6 +131,7 @@ def replace_args_kwargs(method, backend, args, kwargs):
         (np.nanargmax, ([1, 3, 2],), {}),
         (np.nanmin, ([1, 3, 2],), {}),
         (np.nanmax, ([1, 3, 2],), {}),
+        (np.ptp, ([1, 3, 2],), {}),
         (np.unique, ([1, 2, 2],), {}),
         (np.in1d, ([1], [1, 2, 2]), {}),
         (np.isin, ([1], [1, 2, 2]), {}),

--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -169,6 +169,7 @@ def replace_args_kwargs(method, backend, args, kwargs):
         (np.count_nonzero, ([True, False, True, False],), {}),
         (np.linspace, (0, 100, 200), {}),
         (np.logspace, (0, [100, 20], 200), {}),
+        (np.diff, ([1, 3, 2],), {}),
     ],
 )
 def test_functions_coerce(backend, method, args, kwargs):

--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -68,7 +68,6 @@ EXCEPTIONS = {
     (DaskBackend, np.sort_complex),
     (DaskBackend, np.msort),
     (DaskBackend, np.searchsorted),
-    (DaskBackend, np.logspace),
 }
 
 
@@ -168,7 +167,7 @@ def replace_args_kwargs(method, backend, args, kwargs):
         (np.extract, ([True, False, True, False], [0, 1, 2, 3]), {}),
         (np.count_nonzero, ([True, False, True, False],), {}),
         (np.linspace, (0, 100, 200), {}),
-        (np.logspace, (0, [100, 20], 200), {}),
+        (np.logspace, (0, 4, 200), {}),
         (np.diff, ([1, 3, 2],), {}),
     ],
 )

--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -228,6 +228,7 @@ def test_functions_coerce_with_dtype(backend, method, args, kwargs):
         (np.meshgrid, ([1, 2, 3], [4, 5], [0, 1]), {}),
         (np.nonzero, ([3, 1, 2, 4],), {}),
         (np.where, ([[3, 1, 2, 4]],), {}),
+        (np.gradient, ([[0, 1, 2], [3, 4, 5], [6, 7, 8]],), {}),
     ],
 )
 def test_multiple_output(backend, method, args, kwargs):


### PR DESCRIPTION
This PR adds multimethods for the following NumPy functions.

`ptp`, `meshgrid`, `linspace`, `logspace`, `diff`, `gradient`

`ptp` is a reduction (it is basically: `np.max(array) - np.min(array)`)

I was a little unsure about how to properly do the `dtype` handling for `linspace` and `logspace`. I had initially implemented without any special handling in 3d20237, but then updated it in 12ab264 to try and be more consistent with other multimethods in that file. I am not sure if this was done entirely correctly/optimally, so please advise.

The test cases here are very basic, following the example of the existing tests for other functions.

For example, NumPy supports array-like start/stop for `linspace`, but Dask does not, so I didn't test that case in `test_numpy.py` to avoid failures (`DaskBackend` is in FULLY_TESTED_BACKENDS)
