### PR TITLE
Fix `asarray(List)` in the dask backend

### DIFF
--- a/unumpy/dask_backend.py
+++ b/unumpy/dask_backend.py
@@ -26,7 +26,6 @@ class DaskBackend:
         from unumpy import numpy_backend as NumpyBackend
 
         _implementations: Dict = {
-            unumpy.asarray: self.wrap_map_blocks(unumpy.asarray),
             unumpy.ufunc.__call__: self.wrap_map_blocks(unumpy.ufunc.__call__),
             unumpy.ones: self.wrap_uniform_create(unumpy.ones),
             unumpy.zeros: self.wrap_uniform_create(unumpy.zeros),


### PR DESCRIPTION
I'm not 100% sure what's going on in https://github.com/Quansight-Labs/unumpy/pull/60#issuecomment-650271336 but the inferred shape of the array seems to be wrong when `asarray` is implemented this way. I'm guessing dask optimised the `all` away because it expected the array to already be a scalar?

```python
In [6]: np.asarray([1, 2, 3])                                                   
Out[6]: dask.array<asarray, shape=(), dtype=int64, chunksize=(), chunktype=numpy.ndarray>
```

Dask's own `asarray` seems to work fine though and gives the correct shape.