### PR TITLE
Multimethods for indexing routines

### DIFF
--- a/unumpy/__init__.py
+++ b/unumpy/__init__.py
@@ -151,6 +151,7 @@ True
 True
 """
 from ._multimethods import *
+from .lib import c_, r_, s_
 
 from ._version import get_versions
 

--- a/unumpy/_multimethods.py
+++ b/unumpy/_multimethods.py
@@ -1175,7 +1175,26 @@ def indices(dimensions, dtype=int, sparse=False):
     return (mark_dtype(dtype),)
 
 
-@create_numpy(_identity_argreplacer)
+def _ix__default(*args):
+    nd = len(args)
+    out = []
+    for i, arg in enumerate(args):
+        if not isinstance(arg, ndarray):
+            arg = asarray(arg)
+
+        if ndim(arg) != 1:
+            raise ValueError("Cross index must be 1 dimensional.")
+
+        if arg.dtype.kind == "b":
+            arg = nonzero(arg)[0]
+
+        shape = tuple(len(arg) if j == i else 1 for j in range(nd))
+        out.append(arg.reshape(shape))
+
+    return tuple(out)
+
+
+@create_numpy(_identity_argreplacer, default=_ix__default)
 def ix_(*args):
     return ()
 

--- a/unumpy/_multimethods.py
+++ b/unumpy/_multimethods.py
@@ -2020,7 +2020,7 @@ def _place_default(arr, mask, vals):
 
     raveled_mask = ravel(mask)
 
-    n = count_nonzero(raveled_mask)
+    n = int(count_nonzero(raveled_mask))
 
     if len(vals) < n:
         vals = list(itertools.islice(itertools.cycle(vals), n))
@@ -2089,7 +2089,26 @@ def put_along_axis(arr, indices, values, axis):
     return (arr, indices, values)
 
 
-@create_numpy(_first3argreplacer)
+def _putmask_default(a, mask, values):
+    if a.shape != mask.shape:
+        raise ValueError("mask and data must have the same shape.")
+
+    if values.shape == a.shape:
+        copyto(a, values.reshape(a.shape), where=mask)
+    else:
+        n = int(prod(a.shape))
+        values = ravel(values)
+
+        if len(values) < n:
+            values = list(itertools.islice(itertools.cycle(values), n))
+            values = asarray(values)
+        elif len(values_raveled) > n:
+            values = values[:n]
+
+        copyto(a, values.reshape(a.shape), where=mask)
+
+
+@create_numpy(_first3argreplacer, default=_putmask_default)
 @all_of_type(ndarray)
 def putmask(a, mask, values):
     return (a, mask, values)

--- a/unumpy/_multimethods.py
+++ b/unumpy/_multimethods.py
@@ -1189,7 +1189,21 @@ def ravel_multi_index(multi_index, dims, mode="raise", order="C"):
     return (multi_index,)
 
 
-@create_numpy(_self_argreplacer)
+def _unravel_index_default(indices, shape, order="C"):
+    if order == "F":
+        return NotImplemented
+
+    unraveled_coords = []
+    stride = 1
+    for i, dim in enumerate(shape[::-1]):
+        index = (indices // stride) % dim
+        unraveled_coords.append(index)
+        stride *= dim
+
+    return tuple(unraveled_coords[::-1])
+
+
+@create_numpy(_self_argreplacer, default=_unravel_index_default)
 @all_of_type(ndarray)
 def unravel_index(indices, shape, order="C"):
     return (indices,)

--- a/unumpy/_multimethods.py
+++ b/unumpy/_multimethods.py
@@ -1133,6 +1133,122 @@ def where(condition, x=None, y=None):
     return (condition, x, y)
 
 
+@create_numpy(_dtype_argreplacer)
+def indices(dimensions, dtype=int, sparse=False):
+    return (mark_dtype(dtype),)
+
+
+@create_numpy(_identity_argreplacer)
+def ix_(*args):
+    return ()
+
+
+@create_numpy(_identity_argreplacer)
+def ravel_multi_index(multi_index, dims, mode="raise", order="C"):
+    return ()
+
+
+@create_numpy(_self_argreplacer)
+@all_of_type(ndarray)
+def unravel_index(indices, shape, order="C"):
+    return (indices,)
+
+
+@create_numpy(_identity_argreplacer, default=lambda n, ndim=2: (arange(n),) * ndim)
+def diag_indices(n, ndim=2):
+    return ()
+
+
+def _diag_indices_from_default(arr):
+    nd = ndim(arr)
+    if not nd >= 2:
+        raise ValueError("Input array must be at least 2-d.")
+
+    shape = arr.shape
+    dim1 = shape[0]
+    for dim in shape[1:]:
+        if dim != dim1:
+            raise ValueError("All dimensions of input must be of equal length.")
+
+    return diag_indices(dim1, nd)
+
+
+@create_numpy(_self_argreplacer, default=_diag_indices_from_default)
+@all_of_type(ndarray)
+def diag_indices_from(arr):
+    return (arr,)
+
+
+def _mask_indices_default(n, mask_func, k=0):
+    a = ones((n, n))
+    a = mask_func(a, k=k)
+
+    return nonzero(a)
+
+
+@create_numpy(_identity_argreplacer, default=_mask_indices_default)
+def mask_indices(n, mask_func, k=0):
+    return ()
+
+
+def _tril_indices_default(n, k=0, m=None):
+    if m is None:
+        m = n
+
+    a = ones((n, m))
+    a = tril(a, k=k)
+
+    return nonzero(a)
+
+
+@create_numpy(_identity_argreplacer, default=_tril_indices_default)
+def tril_indices(n, k=0, m=None):
+    return ()
+
+
+def _tril_indices_from_default(arr, k=0):
+    if ndim(arr) != 2:
+        raise ValueError("Input array must be 2-d.")
+
+    shape = arr.shape
+    return tril_indices(shape[0], k, shape[1])
+
+
+@create_numpy(_self_argreplacer, default=_tril_indices_from_default)
+@all_of_type(ndarray)
+def tril_indices_from(arr, k=0):
+    return (arr,)
+
+
+def _triu_indices_default(n, k=0, m=None):
+    if m is None:
+        m = n
+
+    a = ones((n, m))
+    a = triu(a, k=k)
+
+    return nonzero(a)
+
+
+@create_numpy(_identity_argreplacer, default=_triu_indices_default)
+def triu_indices(n, k=0, m=None):
+    return ()
+
+
+def _triu_indices_from_default(arr, k=0):
+    if ndim(arr) != 2:
+        raise ValueError("Input array must be 2-d.")
+
+    shape = arr.shape
+    return triu_indices(shape[0], k, shape[1])
+
+
+@create_numpy(_self_argreplacer, default=_triu_indices_from_default)
+@all_of_type(ndarray)
+def triu_indices_from(arr, k=0):
+    return (arr,)
+
+
 @create_numpy(_self_argreplacer)
 @all_of_type(ndarray)
 def pad(array, pad_width, mode, **kwargs):

--- a/unumpy/_multimethods.py
+++ b/unumpy/_multimethods.py
@@ -114,6 +114,13 @@ class ClassOverrideMetaWithConstructorAndGetAttr(
     pass
 
 
+def _call_first_argreplacer(args, kwargs, dispatchables):
+    def replacer(self, a, *args, **kwargs):
+        return (self, dispatchables[0]) + args, kwargs
+
+    return replacer(*args, **kwargs)
+
+
 def _reduce_argreplacer(args, kwargs, arrays):
     def reduce(a, axis=None, dtype=None, out=None, keepdims=False):
         kwargs = {}

--- a/unumpy/_multimethods.py
+++ b/unumpy/_multimethods.py
@@ -102,6 +102,7 @@ class ClassOverrideMetaWithConstructor(ClassOverrideMeta):
         default=lambda self, *a, **kw: self.overridden_class(*a, **kw),
     )
     def __call__(self, *args, **kwargs):
+        self._unwrapped = NotImplemented
         return ()
 
 
@@ -111,15 +112,6 @@ class ClassOverrideMetaWithGetAttr(ClassOverrideMeta):
         default=lambda self, name: getattr(self.overridden_class, name),
     )
     def __getattr__(self, name):
-        return ()
-
-
-class ClassOverrideMetaWithGetItem(ClassOverrideMeta):
-    @create_numpy(
-        _identity_argreplacer,
-        default=lambda self, key: self.overridden_class.__getitem__(key),
-    )
-    def __getitem__(self, key):
         return ()
 
 
@@ -1104,18 +1096,6 @@ def partition(a, kth, axis=-1, kind="introselect", order=None):
 @all_of_type(ndarray)
 def argpartition(a, kth, axis=-1, kind="introselect", order=None):
     return (a,)
-
-
-class c_(metaclass=ClassOverrideMetaWithGetItem):
-    pass
-
-
-class r_(metaclass=ClassOverrideMetaWithGetItem):
-    pass
-
-
-class s_(metaclass=ClassOverrideMetaWithGetItem):
-    pass
 
 
 @create_numpy(_self_argreplacer)

--- a/unumpy/_multimethods.py
+++ b/unumpy/_multimethods.py
@@ -99,6 +99,15 @@ class ClassOverrideMetaWithGetAttr(ClassOverrideMeta):
         return ()
 
 
+class ClassOverrideMetaWithGetItem(ClassOverrideMeta):
+    @create_numpy(
+        _identity_argreplacer,
+        default=lambda self, key: self.overridden_class.__getitem__(key),
+    )
+    def __getitem__(self, key):
+        return ()
+
+
 class ClassOverrideMetaWithConstructorAndGetAttr(
     ClassOverrideMetaWithConstructor, ClassOverrideMetaWithGetAttr
 ):
@@ -1073,6 +1082,18 @@ def partition(a, kth, axis=-1, kind="introselect", order=None):
 @all_of_type(ndarray)
 def argpartition(a, kth, axis=-1, kind="introselect", order=None):
     return (a,)
+
+
+class c_(metaclass=ClassOverrideMetaWithGetItem):
+    pass
+
+
+class r_(metaclass=ClassOverrideMetaWithGetItem):
+    pass
+
+
+class s_(metaclass=ClassOverrideMetaWithGetItem):
+    pass
 
 
 @create_numpy(_self_argreplacer)

--- a/unumpy/_multimethods.py
+++ b/unumpy/_multimethods.py
@@ -1133,7 +1133,23 @@ def where(condition, x=None, y=None):
     return (condition, x, y)
 
 
-@create_numpy(_dtype_argreplacer)
+def _indices_default(dimensions, dtype=int, sparse=False):
+    shape = (1,) * len(dimensions)
+    grid = []
+    for i, dim in enumerate(dimensions):
+        indices = arange(dim, dtype=dtype).reshape(shape[:i] + (dim,) + shape[i + 1 :])
+        if not sparse:
+            indices = broadcast_to(indices, dimensions)
+
+        grid.append(indices)
+
+    if sparse:
+        return tuple(grid)
+    else:
+        return asarray(grid)
+
+
+@create_numpy(_dtype_argreplacer, default=_indices_default)
 def indices(dimensions, dtype=int, sparse=False):
     return (mark_dtype(dtype),)
 

--- a/unumpy/lib/__init__.py
+++ b/unumpy/lib/__init__.py
@@ -1,1 +1,3 @@
 from ._multimethods import *
+from . import index_tricks
+from .index_tricks import c_, r_, s_

--- a/unumpy/lib/__init__.py
+++ b/unumpy/lib/__init__.py
@@ -1,0 +1,1 @@
+from ._multimethods import *

--- a/unumpy/lib/_multimethods.py
+++ b/unumpy/lib/_multimethods.py
@@ -5,8 +5,22 @@ import builtins
 
 create_numpy = functools.partial(create_multimethod, domain="numpy.lib")
 
-from .._multimethods import ClassOverrideMetaWithConstructorAndGetAttr
+from .._multimethods import (
+    ClassOverrideMetaWithGetAttr,
+    _call_first_argreplacer,
+    ndarray,
+)
 
 
-class Arrayterator(metaclass=ClassOverrideMetaWithConstructorAndGetAttr):
+class ClassOverrideMetaForArrayterator(ClassOverrideMetaWithGetAttr):
+    @create_numpy(
+        _call_first_argreplacer,
+        default=lambda self, var, buf_size=None: self.overridden_class(var, buf_size),
+    )
+    @all_of_type(ndarray)
+    def __call__(self, var, buf_size=None):
+        return (var,)
+
+
+class Arrayterator(metaclass=ClassOverrideMetaForArrayterator):
     pass

--- a/unumpy/lib/_multimethods.py
+++ b/unumpy/lib/_multimethods.py
@@ -19,6 +19,7 @@ class ClassOverrideMetaForArrayterator(ClassOverrideMetaWithGetAttr):
     )
     @all_of_type(ndarray)
     def __call__(self, var, buf_size=None):
+        self._unwrapped = NotImplemented
         return (var,)
 
 

--- a/unumpy/lib/_multimethods.py
+++ b/unumpy/lib/_multimethods.py
@@ -1,0 +1,12 @@
+import functools
+import operator
+from uarray import create_multimethod, mark_as, all_of_type, Dispatchable
+import builtins
+
+create_numpy = functools.partial(create_multimethod, domain="numpy.lib")
+
+from .._multimethods import ClassOverrideMetaWithConstructorAndGetAttr
+
+
+class Arrayterator(metaclass=ClassOverrideMetaWithConstructorAndGetAttr):
+    pass

--- a/unumpy/lib/index_tricks/__init__.py
+++ b/unumpy/lib/index_tricks/__init__.py
@@ -1,0 +1,1 @@
+from ._multimethods import *

--- a/unumpy/lib/index_tricks/_multimethods.py
+++ b/unumpy/lib/index_tricks/_multimethods.py
@@ -1,0 +1,35 @@
+import functools
+import operator
+from uarray import create_multimethod, mark_as, all_of_type, Dispatchable
+import builtins
+
+create_numpy = functools.partial(create_multimethod, domain="numpy.lib.index_tricks")
+
+from ..._multimethods import ClassOverrideMetaWithConstructorAndGetAttr
+
+
+class CClass(metaclass=ClassOverrideMetaWithConstructorAndGetAttr):
+    def __getitem__(self, key):
+        return CClass().__getitem__(key)
+
+
+c_ = CClass()
+
+
+class RClass(metaclass=ClassOverrideMetaWithConstructorAndGetAttr):
+    def __getitem__(self, key):
+        return RClass().__getitem__(key)
+
+
+r_ = RClass()
+
+
+class IndexExpression(metaclass=ClassOverrideMetaWithConstructorAndGetAttr):
+    def __init__(self, maketuple):
+        self.maketuple = maketuple
+
+    def __getitem__(self, key):
+        return IndexExpression(self.maketuple).__getitem__(key)
+
+
+s_ = IndexExpression(maketuple=True)

--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -249,6 +249,8 @@ def test_functions_coerce(backend, method, args, kwargs):
                 pytest.xfail(reason="CuPy does not accept array repeats")
         raise
     except ValueError:
+        if isinstance(backend, DaskBackend) and method is np.place:
+            pytest.xfail(reason="Default relies on delete and copyto")
         if backend is CupyBackend and method in {np.argwhere, np.block}:
             pytest.xfail(reason="Default relies on array_like coercion")
         raise

--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -1,3 +1,4 @@
+import collections
 import pytest
 import uarray as ua
 import unumpy as np
@@ -189,6 +190,7 @@ def replace_args_kwargs(method, backend, args, kwargs):
         (np.array_equal, ([1, 2, 3], [1, 2, 3]), {}),
         (np.array_equiv, ([1, 2], [[1, 2], [1, 2]]), {}),
         (np.diag, ([1, 2, 3],), {}),
+        (np.diagonal, ([[0, 1], [2, 3]],), {}),
         (np.diagflat, ([[1, 2], [3, 4]],), {}),
         (np.copy, ([1, 2, 3],), {}),
         (np.tril, ([[1, 2], [3, 4]],), {}),
@@ -215,6 +217,18 @@ def replace_args_kwargs(method, backend, args, kwargs):
         (np.interp, (2.5, [1, 2, 3], [3, 2, 0]), {}),
         (np.indices, ((2, 3),), {}),
         (np.ravel_multi_index, ([[3, 6, 6], [4, 5, 1]], (7, 6)), {}),
+        (np.take, ([4, 3, 5, 7, 6, 8], [0, 1, 4]), {}),
+        (np.take_along_axis, ([[1, 2, 3], [4, 5, 6]], [[0, -1]], 1), {}),
+        (np.choose, ([1, 2, 0], [[0, 1, 2], [10, 11, 12], [20, 21, 22]]), {}),
+        (np.select, ([[True, False], [False, True]], [[0, 0], [1, 1]]), {}),
+        (np.place, ([[1, 2], [3, 4]], [[False, False], [True, True]], [-99, 99]), {}),
+        (np.put, ([0, 1, 2, 3, 4, 5], [0, 2], [-44, -55]), {}),
+        (np.put_along_axis, ([[10, 30, 20], [60, 40, 50]], [[0], [1]], 99, 1), {}),
+        (np.putmask, ([[1, 2], [3, 4]], [[False, False], [True, True]], [-99, 99]), {}),
+        (np.fill_diagonal, ([[0, 0], [0, 0]], 1), {}),
+        (np.nditer, ([[1, 2, 3]],), {}),
+        (np.ndenumerate, ([[1, 2], [3, 4]],), {}),
+        (np.ndindex, (3, 2, 1), {}),
     ],
 )
 def test_functions_coerce(backend, method, args, kwargs):
@@ -261,6 +275,10 @@ def test_functions_coerce(backend, method, args, kwargs):
         np.array_equiv,
     ):
         assert isinstance(ret, (bool,) + types)
+    elif method in {np.place, np.put, np.put_along_axis, np.putmask, np.fill_diagonal}:
+        assert ret is None
+    elif method in {np.nditer, np.ndenumerate, np.ndindex}:
+        assert isinstance(ret, collections.abc.Iterator)
     else:
         assert isinstance(ret, types)
 
@@ -337,6 +355,7 @@ def test_functions_coerce_with_dtype(backend, method, args, kwargs):
         (np.tril_indices_from, ([[1, 2], [3, 4]],), {}),
         (np.triu_indices, (4,), {}),
         (np.triu_indices_from, ([[1, 2], [3, 4]],), {}),
+        (np.nested_iters, ([[0, 1], [2, 3]], [[0], [1]]), {}),
     ],
 )
 def test_multiple_output(backend, method, args, kwargs):
@@ -360,8 +379,10 @@ def test_multiple_output(backend, method, args, kwargs):
                 raise pytest.xfail(
                     reason="Sparse's methods for triangular matrices require an array with zero fill-values as argument."
                 )
-
-    assert all(isinstance(arr, types) for arr in ret)
+    if method is np.nested_iters:
+        assert all(isinstance(ite, collections.abc.Iterator) for ite in ret)
+    else:
+        assert all(isinstance(arr, types) for arr in ret)
 
     for arr in ret:
         if isinstance(arr, da.Array):

--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -229,7 +229,7 @@ def replace_args_kwargs(method, backend, args, kwargs):
         (np.nditer, ([[1, 2, 3]],), {}),
         (np.ndenumerate, ([[1, 2], [3, 4]],), {}),
         (np.ndindex, (3, 2, 1), {}),
-        (np.lib.Arrayterator, ([[1, 2], [3, 4]], 2), {}),
+        (np.lib.Arrayterator, ([[1, 2], [3, 4]],), {}),
     ],
 )
 def test_functions_coerce(backend, method, args, kwargs):

--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -586,6 +586,31 @@ def test_functional(backend, method, args, kwargs):
         ret.compute()
 
 
+@pytest.mark.parametrize(
+    "method, args",
+    [
+        (np.c_, ([1, 2, 3], [4, 5, 6])),
+        (np.r_, ([1, 2, 3], [4, 5, 6])),
+        (np.s_, (slice(2, None, 2))),
+    ],
+)
+def test_class_getitem(backend, method, args):
+    backend, types, = backend
+    try:
+        with ua.set_backend(backend, coerce=True):
+            ret = method[args]
+    except ua.BackendNotImplementedError:
+        if backend in FULLY_TESTED_BACKENDS and (backend, method) not in EXCEPTIONS:
+            raise pytest.xfail(
+                reason="The backend has no implementation for this class."
+            )
+
+    if method is np.s_:
+        assert isinstance(ret, slice)
+    else:
+        assert isinstance(ret, onp.ndarray)
+
+
 def test_class_overriding():
     with ua.set_backend(NumpyBackend, coerce=True):
         assert isinstance(onp.add, np.ufunc)

--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -278,8 +278,10 @@ def test_functions_coerce(backend, method, args, kwargs):
         assert isinstance(ret, (bool,) + types)
     elif method in {np.place, np.put, np.put_along_axis, np.putmask, np.fill_diagonal}:
         assert ret is None
-    elif method in {np.nditer, np.ndenumerate, np.ndindex, np.lib.Arrayterator}:
+    elif method in {np.nditer, np.ndenumerate, np.ndindex}:
         assert isinstance(ret, collections.abc.Iterator)
+    elif method is np.lib.Arrayterator:
+        assert isinstance(ret, collections.abc.Iterable)
     else:
         assert isinstance(ret, types)
 

--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -213,6 +213,8 @@ def replace_args_kwargs(method, backend, args, kwargs):
         (np.nan_to_num, ([np.inf, np.NINF, np.nan],), {}),
         (np.real_if_close, ([2.1 + 4e-14j, 5.2 + 3e-15j],), {}),
         (np.interp, (2.5, [1, 2, 3], [3, 2, 0]), {}),
+        (np.indices, ((2, 3),), {}),
+        (np.ravel_multi_index, ([[3, 6, 6], [4, 5, 1]], (7, 6)), {}),
     ],
 )
 def test_functions_coerce(backend, method, args, kwargs):
@@ -326,6 +328,15 @@ def test_functions_coerce_with_dtype(backend, method, args, kwargs):
         (np.dsplit, ([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], 2), {}),
         (np.hsplit, ([[1, 2], [3, 4]], 2), {}),
         (np.vsplit, ([[1, 2], [3, 4]], 2), {}),
+        (np.ix_, ([0, 1], [2, 4]), {}),
+        (np.unravel_index, ([22, 41, 37], (7, 6)), {}),
+        (np.diag_indices, (4,), {}),
+        (np.diag_indices_from, ([[1, 2], [3, 4]],), {}),
+        (np.mask_indices, (3, np.triu), {}),
+        (np.tril_indices, (4,), {}),
+        (np.tril_indices_from, ([[1, 2], [3, 4]],), {}),
+        (np.triu_indices, (4,), {}),
+        (np.triu_indices_from, ([[1, 2], [3, 4]],), {}),
     ],
 )
 def test_multiple_output(backend, method, args, kwargs):

--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -616,7 +616,7 @@ def test_functional(backend, method, args, kwargs):
     [
         (np.c_, ([1, 2, 3], [4, 5, 6])),
         (np.r_, ([1, 2, 3], [4, 5, 6])),
-        (np.s_, (slice(2, None, 2))),
+        (np.s_, (slice(2, None, 2),)),
     ],
 )
 def test_class_getitem(backend, method, args):
@@ -626,14 +626,13 @@ def test_class_getitem(backend, method, args):
             ret = method[args]
     except ua.BackendNotImplementedError:
         if backend in FULLY_TESTED_BACKENDS and (backend, method) not in EXCEPTIONS:
-            raise pytest.xfail(
-                reason="The backend has no implementation for this class."
-            )
+            raise
+        pytest.xfail(reason="The backend has no implementation for this class.")
 
     if method is np.s_:
-        assert isinstance(ret, slice)
+        all(isinstance(s, slice) for s in ret)
     else:
-        assert isinstance(ret, onp.ndarray)
+        assert isinstance(ret, types)
 
 
 def test_class_overriding():

--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -348,6 +348,18 @@ def test_multiple_output(backend, method, args, kwargs):
         if backend in FULLY_TESTED_BACKENDS and (backend, method) not in EXCEPTIONS:
             raise
         pytest.xfail(reason="The backend has no implementation for this ufunc.")
+    except ValueError:
+        if backend is SparseBackend:
+            if method in {
+                np.mask_indices,
+                np.tril_indices,
+                np.tril_indices_from,
+                np.triu_indices,
+                np.triu_indices_from,
+            }:
+                raise pytest.xfail(
+                    reason="Sparse's methods for triangular matrices require an array with zero fill-values as argument."
+                )
 
     assert all(isinstance(arr, types) for arr in ret)
 

--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -229,6 +229,7 @@ def replace_args_kwargs(method, backend, args, kwargs):
         (np.nditer, ([[1, 2, 3]],), {}),
         (np.ndenumerate, ([[1, 2], [3, 4]],), {}),
         (np.ndindex, (3, 2, 1), {}),
+        (np.lib.Arrayterator, ([[1, 2], [3, 4]], 2), {}),
     ],
 )
 def test_functions_coerce(backend, method, args, kwargs):
@@ -277,7 +278,7 @@ def test_functions_coerce(backend, method, args, kwargs):
         assert isinstance(ret, (bool,) + types)
     elif method in {np.place, np.put, np.put_along_axis, np.putmask, np.fill_diagonal}:
         assert ret is None
-    elif method in {np.nditer, np.ndenumerate, np.ndindex}:
+    elif method in {np.nditer, np.ndenumerate, np.ndindex, np.lib.Arrayterator}:
         assert isinstance(ret, collections.abc.Iterator)
     else:
         assert isinstance(ret, types)
@@ -379,6 +380,10 @@ def test_multiple_output(backend, method, args, kwargs):
                 raise pytest.xfail(
                     reason="Sparse's methods for triangular matrices require an array with zero fill-values as argument."
                 )
+    except TypeError:
+        if backend is CupyBackend and method is np.unravel_index:
+            pytest.xfail(reason="cupy.unravel_index is broken in version 6.0")
+        raise
     if method is np.nested_iters:
         assert all(isinstance(ite, collections.abc.Iterator) for ite in ret)
     else:


### PR DESCRIPTION
This PR intends to expand unumpy's coverage of [indexing](https://numpy.org/doc/stable/reference/routines.indexing.html) routines. The multimethods added so far are the following:

**Generating index arrays**

- `indices`
- `ix_`
- `ravel_multi_index`
- `unravel_index`
- `diag_indices`
- `diag_indices_from`
- `mask_indices`
- `tril_indices`
- `tril_indices_from`
- `triu_indices`
- `triu_indices_from`

Some observations:

1. The failing tests are in the Sparse backend. Because `ones` creates a COO with a `fill_value` of 1.0, the call to the next method fails since a zero `fill_value` is necessary.
2. I'm working on default implementations for `ravel_multi_index` and `unravel_index`. I'll push them as soon as I have a working prototype but tips on how to implement these are welcomed.
3. There are three classes that should be added as well since they are part of these routines, they are `c_`, `r_` and `s_`.

**Note:** I'll be adding more multimethods that target these routines later.