### PR TITLE
Multimethods for statistical functions

### DIFF
--- a/unumpy/tests/test_numpy.py
+++ b/unumpy/tests/test_numpy.py
@@ -119,6 +119,8 @@ def replace_args_kwargs(method, backend, args, kwargs):
         (np.argmax, ([1, 3, 2],), {}),
         (np.nanargmin, ([1, 3, 2],), {}),
         (np.nanargmax, ([1, 3, 2],), {}),
+        (np.amin, ([1, 3, 2],), {}),
+        (np.amax, ([1, 3, 2],), {}),
         (np.nanmin, ([1, 3, 2],), {}),
         (np.nanmax, ([1, 3, 2],), {}),
         (np.ptp, ([1, 3, 2],), {}),


### PR DESCRIPTION
This pull request adds multimethods for [statistical functions](https://numpy.org/doc/stable/reference/routines.statistics.html). The multimethods added are the following:

**Order statistics**

- `percentile`
- `nanpercentile`
- `quantile`
- `nanquantile`

**Averages and variances**

- `median`
- `average`
- `mean`
- `nanmedian`
- `nanmean`
- `nanstd`
- `nanvar`

**Correlating**

- `corrcoef`
- `correlate`
- `cov`

**Histograms**

- `histogram`
- `histogram2d`
- `histogramdd`
- `bincount`
- `histogram_bin_edges`
- `digitize`

A few things to discuss:

1. Why is `dtype` not being dispatched in `std` and `var`? Other multimethods that use `_reduce_argreplacer` also don't dispatch `dtype`.
2. The previously added `min` and `max` seem to be equal to `amin` and `amax` that this PR intends to add:
```python
In [2]: onp.amin                                                                
Out[2]: <function numpy.amin(a, axis=None, out=None, keepdims=<no value>, initial=<no value>, where=<no value>)>

In [3]: onp.min                                                                 
Out[3]: <function numpy.amin(a, axis=None, out=None, keepdims=<no value>, initial=<no value>, where=<no value>)>
```
3. I'm looking into implementing some defaults as well. Multimethods like `median` that reduce array slices along an axis might be the easier ones for now. As I understand these require a for loop over the given axis, so in terms of complexity it would be O(n) where n is the length of that dimension.